### PR TITLE
Update pgmspace.h

### DIFF
--- a/api/deprecated-avr-comp/avr/pgmspace.h
+++ b/api/deprecated-avr-comp/avr/pgmspace.h
@@ -30,7 +30,9 @@
 #include <inttypes.h>
 
 #define PROGMEM
+#define __ATTR_PROGMEM__ 
 #define PGM_P  const char *
+#define PGM_VOID_P const void *
 #define PSTR(str) (str)
 
 #define _SFR_BYTE(n) (n)


### PR DESCRIPTION
Some macros were missing from the compatibility header.
I added `PGM_VOID_P` and the `__ATTR_PROGMEM__` macros to the compatibility header.